### PR TITLE
Table Generator Read and Delete - 4/18

### DIFF
--- a/src/main/java/com/nighthawk/spring_portfolio/MvcConfig.java
+++ b/src/main/java/com/nighthawk/spring_portfolio/MvcConfig.java
@@ -24,7 +24,9 @@ public class MvcConfig implements WebMvcConfigurer {
     
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**").allowedOrigins("https://john-scc.github.io", "http://localhost:4100", "http://127.0.0.1:4100");
+        registry.addMapping("/**")
+        .allowedOrigins("https://john-scc.github.io", "http://localhost:4100", "http://127.0.0.1:4100")
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
     }
     
 }

--- a/src/main/java/com/nighthawk/spring_portfolio/SecurityConfig.java
+++ b/src/main/java/com/nighthawk/spring_portfolio/SecurityConfig.java
@@ -92,7 +92,7 @@ public class SecurityConfig {
 					.addHeaderWriter(new StaticHeadersWriter("Access-Control-Allow-ExposedHeaders", "*", "Authorization"))
 					.addHeaderWriter(new StaticHeadersWriter("Access-Control-Allow-Headers", "Content-Type", "Authorization", "x-csrf-token"))
 					.addHeaderWriter(new StaticHeadersWriter("Access-Control-Allow-MaxAge", "600"))
-					.addHeaderWriter(new StaticHeadersWriter("Access-Control-Allow-Methods", "POST", "GET", "OPTIONS", "HEAD"))
+					.addHeaderWriter(new StaticHeadersWriter("Access-Control-Allow-Methods", "POST", "GET", "OPTIONS", "HEAD", "PATCH", "DELETE"))
 					//.addHeaderWriter(new StaticHeadersWriter("Access-Control-Allow-Origin", "https://john-scc.github.io"))
 					//.addHeaderWriter(new StaticHeadersWriter("Access-Control-Allow-Origin", "http://localhost:4100"))
 				)

--- a/src/main/java/com/nighthawk/spring_portfolio/mvc/classPeriod/ClassPeriod.java
+++ b/src/main/java/com/nighthawk/spring_portfolio/mvc/classPeriod/ClassPeriod.java
@@ -82,6 +82,13 @@ public class ClassPeriod {
     @Column(columnDefinition = "jsonb")
     private Map<Integer,Map<Integer, String>> seatingChart = new HashMap<>(); 
     
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setStudents(ArrayList arr) {
+        this.students = arr;
+    }
 
     // Constructor used when building object from an API
     public ClassPeriod(String name) {

--- a/src/main/java/com/nighthawk/spring_portfolio/mvc/classPeriod/ClassPeriodApiController.java
+++ b/src/main/java/com/nighthawk/spring_portfolio/mvc/classPeriod/ClassPeriodApiController.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import com.nighthawk.spring_portfolio.mvc.person.Person;
 import com.nighthawk.spring_portfolio.mvc.person.PersonJpaRepository;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.nighthawk.spring_portfolio.mvc.jwt.JwtTokenUtil;
 
 import java.util.*;
@@ -197,4 +198,36 @@ public class ClassPeriodApiController {
         // return Bad ID
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST); 
     }
+
+    @PutMapping("/update/{id}")
+    public ResponseEntity<?> updateClassPeriod(@PathVariable long id, @RequestBody JsonNode requestBody) {
+        ClassPeriod classPeriod = repository.findById(id);
+
+        // Extract name from the request body
+        String name = requestBody.get("name").asText();
+
+        // Extract students from the request body and convert them to an ArrayList<String>
+        JsonNode studentsNode = requestBody.get("class");
+        ArrayList<String> students = new ArrayList<>();
+        if (studentsNode.isArray()) {
+            for (JsonNode studentNode : studentsNode) {
+                students.add(studentNode.asText());
+            }
+        }
+
+        // Set the properties of the existing class period
+        classPeriod.setName(name);
+        classPeriod.setStudents(students);
+
+        // Print for verification
+        System.out.println("Name: " + name);
+        System.out.println("Students: " + students);
+
+        // Save the updated class period to the database
+        repository.save(classPeriod);
+
+        // Return an appropriate response
+        return new ResponseEntity<>("Class period updated successfully", HttpStatus.OK);
+    }
 }
+

--- a/src/main/java/com/nighthawk/spring_portfolio/mvc/jwt/JwtApiController.java
+++ b/src/main/java/com/nighthawk/spring_portfolio/mvc/jwt/JwtApiController.java
@@ -1,6 +1,7 @@
 package com.nighthawk.spring_portfolio.mvc.jwt;
 
 import java.util.stream.Collectors;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -67,7 +68,9 @@ public class JwtApiController {
 			.sameSite("None; Secure")
 			.build();
 
-		return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, tokenCookie.toString()).body(authenticationRequest.getEmail() + " was authenticated successfully");
+		return ResponseEntity.ok()
+			.header(HttpHeaders.SET_COOKIE, tokenCookie.toString())
+			.body(Map.of("message", authenticationRequest.getEmail() + " was authenticated successfully", "cookie", tokenCookie.getValue()));
 	}
 
 	/* leftover cookie tester method


### PR DESCRIPTION
## Feature Update

The table generator on the frontend is now able to read a user's classes and delete them, which involved very little editing of the backend aside from adding allowed methods onto our ``MvcConfig.java`` file, because apparently the methods on ``SecurityConfig.java`` do nothing, as after testing removing "READ" from ``SecurityConfig.java``, all requests with the "READ" method still worked.

```java
@Override
    public void addCorsMappings(CorsRegistry registry) {
        registry.addMapping("/**")
        .allowedOrigins("https://john-scc.github.io", "http://localhost:4100", "http://127.0.0.1:4100")
        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
    }
```